### PR TITLE
Set encoding for Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 import versioneer
 
-with open("README.md") as fh:
+with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 with open("requirements.txt") as fh:
     requirements = [line.strip() for line in fh]


### PR DESCRIPTION
There was no encoding specified when [opening the README](https://github.com/xarray-contrib/cupy-xarray/blob/a1879ab8609d872a7fb7525cbae1ee6e7de68264/setup.py#L5-L6) in `setup.py`, so Python defaults to `locale.getpreferredencoding()`. On Windows, it tries to open with `cp1252` encoding, which breaks installation.

```python
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 24: character maps to <undefined>
```

This PR just specifies `utf-8` encoding so that `setup.py` runs as expected on Windows. 

Hope you don't mind the PR without opening an issue since it's such a quick fix, but I'm happy to discuss!