### PR TITLE
Fix broken dask_array_type import

### DIFF
--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -5,7 +5,10 @@ from xarray import (
     register_dataarray_accessor,
     register_dataset_accessor,
 )
-from xarray.core.pycompat import dask_array_type
+from xarray.core.pycompat import DuckArrayModule
+
+dsk = DuckArrayModule("dask")
+dask_array_type = dsk.type
 
 
 @register_dataarray_accessor("cupy")


### PR DESCRIPTION
By this pull request I tried to solve the [issue](https://github.com/xarray-contrib/cupy-xarray/issues/23#issue-1518784549)