### PR TITLE
Kadykov pint

### DIFF
--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -7,8 +7,8 @@ from xarray import (
 )
 from xarray.core.pycompat import DuckArrayModule
 
-dsk = DuckArrayModule("dask")
-dask_array_type = dsk.type
+dask_array_type = DuckArrayModule("dask").type
+pint_array_type = DuckArrayModule("pint").type
 
 
 @register_dataarray_accessor("cupy")
@@ -26,6 +26,8 @@ class CupyDataArrayAccessor:
         """bool: The underlying data is a cupy array."""
         if isinstance(self.da.data, dask_array_type):
             return isinstance(self.da.data._meta, cp.ndarray)
+        if isinstance(self.da.data, pint_array_type):
+            return isinstance(self.da.data.magnitude, cp.ndarray)
         return isinstance(self.da.data, cp.ndarray)
 
     def as_cupy(self):

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -5,7 +5,10 @@ from xarray import (
     register_dataarray_accessor,
     register_dataset_accessor,
 )
-from xarray.core.pycompat import dask_array_type
+from xarray.core.pycompat import DuckArrayModule
+
+dsk = DuckArrayModule("dask")
+dask_array_type = dsk.type
 
 
 @register_dataarray_accessor("cupy")


### PR DESCRIPTION
This commit fixes the following issue of the wrong behavior of `is_cupy` property with pint xarrays:
```pythonimport numpy as np
import xarray as xr
import cupy as cp
import pint_xarray
import cupy_xarray
from pint_xarray import unit_registry as ureg

cp_da = xr.DataArray(
    cp.linspace(0, 1, 11),
    coords=dict(
        x=np.linspace(0, 10, 11),
    ),
)

pint_da = cp_da.pint.quantify("meter")

print(f"is_cupy response: {pint_da.cupy.is_cupy}")
print(f"pint_da type {type(pint_da.pint.magnitude)}")
```
Currently, the output is:
```sh
is_cupy response: False
pint_da type <class 'cupy.ndarray'>
```