### PR TITLE
Setup GitHub Action Continuout Integration tests

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,42 @@
+name: Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.12']
+        os: [ubuntu-24.04]
+
+    steps:
+    # Checkout current git repository
+    - name: Checkout
+      uses: actions/checkout@v4.1.7
+
+    # Install Python
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5.1.0
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    # Install dependencies from requirements.txt file
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements_test.txt ]; then pip install -r requirements_test.txt; fi
+        python -m pip install .
+
+    # Run the unit tests
+    - name: Test with pytest
+      run: |
+        pytest --verbose cupy_xarray/tests/


### PR DESCRIPTION
Minimal configuration to run unit tests on [GitHub Actions](https://github.com/actions) CI. Using [pytest](https://github.com/pytest-dev/pytest/tree/8.2.2) to run the test suite.

Running matrix tests on Ubuntu-22.04 and Python 3.10/3.12.

TODO:
- [ ] Initial ci-tests.yml file for running GitHub Actions
- [ ] Fix broken unit tests
- [ ] Simplify installation of optional test dependencies

References:
- https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python

Fixes #8