### PR TITLE
Fix broken doctest and tests on accessors

### DIFF
--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -5,10 +5,13 @@ from xarray import (
     register_dataarray_accessor,
     register_dataset_accessor,
 )
-from xarray.namedarray.pycompat import DuckArrayModule
 
-dsk = DuckArrayModule("dask")
-dask_array_type = dsk.type
+try:
+    import dask.array
+
+    dask_array_type = dask.array.Array
+except ImportError:
+    dask_array_type = None
 
 
 @register_dataarray_accessor("cupy")

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -55,7 +55,7 @@ class CupyDataArrayAccessor:
         >>> da = xr.tutorial.load_dataset("air_temperature").air
         >>> gda = da.cupy.as_cupy()
         >>> type(gda.data)
-        <class 'cupy.core.core.ndarray'>
+        <class 'cupy.ndarray'>
 
         """
         if isinstance(self.da.data, dask_array_type):

--- a/cupy_xarray/tests/test_accessors.py
+++ b/cupy_xarray/tests/test_accessors.py
@@ -1,12 +1,15 @@
 import numpy as np
 import pytest
 import xarray as xr
-from xarray.namedarray.pycompat import DuckArrayModule
 
 import cupy_xarray  # noqa: F401
 
-dsk = DuckArrayModule("dask")
-dask_array_type = dsk.type
+try:
+    import dask.array
+
+    dask_array_type = dask.array.Array
+except ImportError:
+    dask_array_type = None
 
 
 @pytest.fixture

--- a/cupy_xarray/tests/test_accessors.py
+++ b/cupy_xarray/tests/test_accessors.py
@@ -1,9 +1,12 @@
 import numpy as np
 import pytest
 import xarray as xr
-from xarray.core.pycompat import dask_array_type
+from xarray.namedarray.pycompat import DuckArrayModule
 
 import cupy_xarray  # noqa: F401
+
+dsk = DuckArrayModule("dask")
+dask_array_type = dsk.type
 
 
 @pytest.fixture

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -132,7 +132,7 @@ Running the test suite
 *cupy-xarray* uses the `pytest <https://docs.pytest.org/en/latest/contents.html>`_
 framework for testing. You can run the test suite using::
 
-    pytest cupy-xarray
+    pytest --doctest-modules cupy_xarray
 
 Contributing documentation
 ==========================


### PR DESCRIPTION
Couple of tests to fix when running `pytest --verbose --doctest-modules cupy_xarray`:

- On `cupy_xarray.accessors.CupyDataArrayAccessor.as_cupy`, output type should now be `cupy.ndarray` instead of `cupy.core.core.ndarray`
- There was an error like `ModuleNotFoundError: No module named 'xarray.core.pycompat'` when running on `xarray=2024.6.0`. Need to apply a patch similar in concept to #24, but without importing `xarray.core.pycompat` (since it is a private function?). Specifically, change the `from xarray.core.pycompat import dask_array_type` line to:
    ```python
    try:
        import dask.array
    
        dask_array_type = dask.array.Array
    except ImportError:
        dask_array_type = None
    ```

Partially cherry-picked from #45. These changes will need to be tested locally with a CUDA GPU device for now, until we can get CI working somehow.