### PR TITLE
Migrate flake8, isort, black rules to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,10 +38,14 @@ repos:
     hooks:
       - id: blackdoc
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.10
     hooks:
-      - id: flake8
+      - id: ruff
+        types_or: [python, pyi, jupyter]
+        args: [--fix]
+      - id: ruff-format
+        types_or: [python, pyi, jupyter]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,6 @@ repos:
         args:
           - "--py38-plus"
 
-  - repo: https://github.com/psf/black
-    rev: 24.3.0
-    hooks:
-      - id: black
-      - id: black-jupyter
-
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.9
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,6 @@ repos:
       - id: ruff-format
         types_or: [python, pyi, jupyter]
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -127,7 +127,7 @@ class CupyDatasetAccessor:
         is_cupy: bool
             Whether the underlying data is a cupy array.
         """
-        return all([da.cupy.is_cupy for da in self.ds.data_vars.values()])
+        return all(da.cupy.is_cupy for da in self.ds.data_vars.values())
 
     def as_cupy(self):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[tool.black]
-line-length = 100
-target-version = ['py38']
-
 [tool.ruff]
 line-length = 100  # E501 (line-too-long)
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ select = [
     "C90",  # mccabe
     "E",    # pycodestyle
     "F",    # pyflakes
+    "I",    # isort
     "SIM",  # flake8-simplify
     "W",    # pycodestyle warnings
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,21 @@
 [tool.black]
 line-length = 100
 target-version = ['py38']
+
+[tool.ruff]
+line-length = 100  # E501 (line-too-long)
+exclude = [
+    "docs",
+    "versioneer.py",
+    "cupy_xarray/_version.py",
+]
+
+[tool.ruff.lint]
+select = [
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "C90",  # mccabe
+    "E",    # pycodestyle
+    "F",    # pyflakes
+    "W",    # pycodestyle warnings
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,6 @@ select = [
     "C90",  # mccabe
     "E",    # pycodestyle
     "F",    # pyflakes
+    "SIM",  # flake8-simplify
     "W",    # pycodestyle warnings
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,13 +6,6 @@ versionfile_build = cupy_xarray/_version.py
 tag_prefix =
 parentdir_prefix =
 
-[flake8]
-exclude = docs,versioneer.py,cupy_xarray/_version.py
-ignore = E203,E266,E501,W503,E722,E402,C901,E731
-max-line-length = 100
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
-
 [isort]
 profile=black
 skip=

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,11 +5,3 @@ versionfile_source = cupy_xarray/_version.py
 versionfile_build = cupy_xarray/_version.py
 tag_prefix =
 parentdir_prefix =
-
-[isort]
-profile=black
-skip=
-    docs/source/conf.py
-    setup.py
-    versioneer.py
-    cupy_xarray/_version.py


### PR DESCRIPTION
Translating the previous flake8 rules in `setup.cfg` to ruff rules in `pyproject.toml`. Original rules were set in #15.

The following ruff lint rules are set:
- **B** - flake8-bugbear
- **C4** -flake8-comprehensions
- **C90** - mccabe
- **E** - pycodestyle
- **F** - pyflakes
- **I** - isort
- **SIM** - flake8-simplify
- **W** - pycodestyle warnings

Notes:
- Did not keep any of the ignored rules (E203,E266,E501,W503,E722,E402,C901,E731) since none of them were triggered
- Dropped the deprecated [flake8-mypy](https://github.com/ambv/flake8-mypy) (T4) rule.

References:
- https://docs.astral.sh/ruff/rules

Part of effort at #47 to remove the setup.cfg file.