### PR TITLE
Bump to ubuntu-24.04 and mambaforge-23.11 in ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,9 +2,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-23.11"
 
 # Optionally set the version of Python and requirements required to build your docs
 conda:


### PR DESCRIPTION
Bump ReadTheDocs os version from `ubuntu-20.04` to `ubuntu-24.04`, and mambaforge version from `4.10` to `23.11`.

References:
- https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os
- https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python.