### PR TITLE
Changelog entry for v0.1.4

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,5 @@
-API
-===
+API Reference
+=============
 
 .. currentmodule:: xarray
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,18 +9,18 @@ Contributing Guide and API reference. It also fixes a `No module named
 
 ### What's Changed
 
-* Documentation Updates 📖 ([#35](https://github.com/xarray-contrib/cupy-xarray/pull/35))
-* Update accessors.py ([#42](https://github.com/xarray-contrib/cupy-xarray/pull/42))
-* Enable API reference docs to show accessor methods ([#44](https://github.com/xarray-contrib/cupy-xarray/pull/44))
-* Migrate flake8, isort, black rules to ruff ([#49](https://github.com/xarray-contrib/cupy-xarray/pull/49))
-* Fix broken doctest and tests on accessors ([#46](https://github.com/xarray-contrib/cupy-xarray/pull/46))
-* Migrate from setup.cfg to pyproject.toml ([#48](https://github.com/xarray-contrib/cupy-xarray/pull/48))
+- Documentation Updates 📖 ([#35](https://github.com/xarray-contrib/cupy-xarray/pull/35))
+- Update accessors.py ([#42](https://github.com/xarray-contrib/cupy-xarray/pull/42))
+- Enable API reference docs to show accessor methods ([#44](https://github.com/xarray-contrib/cupy-xarray/pull/44))
+- Migrate flake8, isort, black rules to ruff ([#49](https://github.com/xarray-contrib/cupy-xarray/pull/49))
+- Fix broken doctest and tests on accessors ([#46](https://github.com/xarray-contrib/cupy-xarray/pull/46))
+- Migrate from setup.cfg to pyproject.toml ([#48](https://github.com/xarray-contrib/cupy-xarray/pull/48))
 
 ### Contributors
 
-* [Wei Ji Leong](https://github.com/weiji14)
-* [Negin Sobhani](https://github.com/negin513)
-* [Sai Shashank](https://github.com/saishashank85)
+- [Wei Ji Leong](https://github.com/weiji14)
+- [Negin Sobhani](https://github.com/negin513)
+- [Sai Shashank](https://github.com/saishashank85)
 
 **Full Changelog**: <https://github.com/xarray-contrib/cupy-xarray/compare/0.1.3...0.1.4>
 
@@ -30,16 +30,16 @@ Contributing Guide and API reference. It also fixes a `No module named
 
 ### What's Changed
 
-* Set encoding for Windows ([#20](https://github.com/xarray-contrib/cupy-xarray/pull/20))
-* Fix broken dask_array_type import ([#24](https://github.com/xarray-contrib/cupy-xarray/pull/24))
-* Min xarray >= 0.19.0 ([#25](https://github.com/xarray-contrib/cupy-xarray/pull/25))
-* Expand installation doc ([#27](https://github.com/xarray-contrib/cupy-xarray/pull/27))
+- Set encoding for Windows ([#20](https://github.com/xarray-contrib/cupy-xarray/pull/20))
+- Fix broken dask_array_type import ([#24](https://github.com/xarray-contrib/cupy-xarray/pull/24))
+- Min xarray >= 0.19.0 ([#25](https://github.com/xarray-contrib/cupy-xarray/pull/25))
+- Expand installation doc ([#27](https://github.com/xarray-contrib/cupy-xarray/pull/27))
 
 ### Contributors
 
-* [Deepak Cherian](https://github.com/dcherian)
-* [Aaron Zuspan](https://github.com/aazuspan)
-* [Aleksandr Kadykov](https://github.com/kadykov)
+- [Deepak Cherian](https://github.com/dcherian)
+- [Aaron Zuspan](https://github.com/aazuspan)
+- [Aleksandr Kadykov](https://github.com/kadykov)
 
 **Full Changelog**: <https://github.com/xarray-contrib/cupy-xarray/compare/0.1.2...0.1.3>
 
@@ -49,15 +49,15 @@ Contributing Guide and API reference. It also fixes a `No module named
 
 ### What's Changed
 
-* Add badges ([#16](https://github.com/xarray-contrib/cupy-xarray/pull/16))
-* update PyPI workflow: double-check we're shipping everything we need ([#17](https://github.com/xarray-contrib/cupy-xarray/pull/17))
-* PyPI workflow: re-introduce upload job ([#18](https://github.com/xarray-contrib/cupy-xarray/pull/18))
-* Revert back to previous version of PyPI workflow ([#19](https://github.com/xarray-contrib/cupy-xarray/pull/19))
+- Add badges ([#16](https://github.com/xarray-contrib/cupy-xarray/pull/16))
+- update PyPI workflow: double-check we're shipping everything we need ([#17](https://github.com/xarray-contrib/cupy-xarray/pull/17))
+- PyPI workflow: re-introduce upload job ([#18](https://github.com/xarray-contrib/cupy-xarray/pull/18))
+- Revert back to previous version of PyPI workflow ([#19](https://github.com/xarray-contrib/cupy-xarray/pull/19))
 
 ### Contributors
 
-* [Deepak Cherian](https://github.com/dcherian)
-* [Anderson Banihirwe](https://github.com/andersy005)
+- [Deepak Cherian](https://github.com/dcherian)
+- [Anderson Banihirwe](https://github.com/andersy005)
 
 **Full Changelog**: <https://github.com/xarray-contrib/cupy-xarray/compare/0.1.1...0.1.2>
 
@@ -69,19 +69,19 @@ _First release!_
 
 ### What's Changed
 
-* Add LICENSE ([#2](https://github.com/xarray-contrib/cupy-xarray/pull/2))
-* Update path of repo ([#3](https://github.com/xarray-contrib/cupy-xarray/pull/3))
-* Add docs ([#4](https://github.com/xarray-contrib/cupy-xarray/pull/4))
-* Update versioneer ([#12](https://github.com/xarray-contrib/cupy-xarray/pull/12))
-* Add PyPI release workflow ([#13](https://github.com/xarray-contrib/cupy-xarray/pull/13))
-* Fix CI job dependency ([#14](https://github.com/xarray-contrib/cupy-xarray/pull/14))
+- Add LICENSE ([#2](https://github.com/xarray-contrib/cupy-xarray/pull/2))
+- Update path of repo ([#3](https://github.com/xarray-contrib/cupy-xarray/pull/3))
+- Add docs ([#4](https://github.com/xarray-contrib/cupy-xarray/pull/4))
+- Update versioneer ([#12](https://github.com/xarray-contrib/cupy-xarray/pull/12))
+- Add PyPI release workflow ([#13](https://github.com/xarray-contrib/cupy-xarray/pull/13))
+- Fix CI job dependency ([#14](https://github.com/xarray-contrib/cupy-xarray/pull/14))
 
 ### Contributors
 
-* [Jacob Tomlinson](https://github.com/jacobtomlinson)
-* [Ray Bell](https://github.com/raybellwaves)
-* [Deepak Cherian](https://github.com/dcherian)
-* [Anderson Banihirwe](https://github.com/andersy005)
+- [Jacob Tomlinson](https://github.com/jacobtomlinson)
+- [Ray Bell](https://github.com/raybellwaves)
+- [Deepak Cherian](https://github.com/dcherian)
+- [Anderson Banihirwe](https://github.com/andersy005)
 
 **Full Changelog**: <https://github.com/xarray-contrib/cupy-xarray/compare/0.1.0...0.1.1>
 
@@ -93,6 +93,6 @@ _Pre-release_
 
 ### Contributors
 
-* [Jacob Tomlinson](https://github.com/jacobtomlinson)
+- [Jacob Tomlinson](https://github.com/jacobtomlinson)
 
 **Full Changelog**: <https://github.com/xarray-contrib/cupy-xarray/compare/0.0.1...0.1.0>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Version 0.1.4 - 2023-07-27
+
+This release brings several documentation improvements at
+<https://cupy-xarray.readthedocs.io> with a new User Guide, Tutorials and Presentations,
+Contributing Guide and API reference. It also fixes a `No module named
+'xarray.core.pycompat'` bug, and will require a minimum version of `xarray>=2024.02.0`.
+
+### What's Changed
+
+* Documentation Updates 📖 ([#35](https://github.com/xarray-contrib/cupy-xarray/pull/35))
+* Update accessors.py ([#42](https://github.com/xarray-contrib/cupy-xarray/pull/42))
+* Enable API reference docs to show accessor methods ([#44](https://github.com/xarray-contrib/cupy-xarray/pull/44))
+* Migrate flake8, isort, black rules to ruff ([#49](https://github.com/xarray-contrib/cupy-xarray/pull/49))
+* Fix broken doctest and tests on accessors ([#46](https://github.com/xarray-contrib/cupy-xarray/pull/46))
+* Migrate from setup.cfg to pyproject.toml ([#48](https://github.com/xarray-contrib/cupy-xarray/pull/48))
+
+### Contributors
+
+* [Wei Ji Leong](https://github.com/weiji14)
+* [Negin Sobhani](https://github.com/negin513)
+* [Sai Shashank](https://github.com/saishashank85)
+
+**Full Changelog**: <https://github.com/xarray-contrib/cupy-xarray/compare/0.1.3...0.1.4>
+
+---
+
 ## Version 0.1.3 - 2023-02-22
 
 ### What's Changed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,72 @@
+# Changelog
+
+## Version 0.1.3 - 2023-02-22
+
+### What's Changed
+
+* Set encoding for Windows ([#20](https://github.com/xarray-contrib/cupy-xarray/pull/20))
+* Fix broken dask_array_type import ([#24](https://github.com/xarray-contrib/cupy-xarray/pull/24))
+* Min xarray >= 0.19.0 ([#25](https://github.com/xarray-contrib/cupy-xarray/pull/25))
+* Expand installation doc ([#27](https://github.com/xarray-contrib/cupy-xarray/pull/27))
+
+### Contributors
+
+* [Deepak Cherian](https://github.com/dcherian)
+* [Aaron Zuspan](https://github.com/aazuspan)
+* [Aleksandr Kadykov](https://github.com/kadykov)
+
+**Full Changelog**: <https://github.com/xarray-contrib/cupy-xarray/compare/0.1.2...0.1.3>
+
+---
+
+## Version 0.1.2 - 2022-08-25
+
+### What's Changed
+
+* Add badges ([#16](https://github.com/xarray-contrib/cupy-xarray/pull/16))
+* update PyPI workflow: double-check we're shipping everything we need ([#17](https://github.com/xarray-contrib/cupy-xarray/pull/17))
+* PyPI workflow: re-introduce upload job ([#18](https://github.com/xarray-contrib/cupy-xarray/pull/18))
+* Revert back to previous version of PyPI workflow ([#19](https://github.com/xarray-contrib/cupy-xarray/pull/19))
+
+### Contributors
+
+* [Deepak Cherian](https://github.com/dcherian)
+* [Anderson Banihirwe](https://github.com/andersy005)
+
+**Full Changelog**: <https://github.com/xarray-contrib/cupy-xarray/compare/0.1.1...0.1.2>
+
+---
+
+## Version 0.1.1 - 2022-08-19
+
+_First release!_
+
+### What's Changed
+
+* Add LICENSE ([#2](https://github.com/xarray-contrib/cupy-xarray/pull/2))
+* Update path of repo ([#3](https://github.com/xarray-contrib/cupy-xarray/pull/3))
+* Add docs ([#4](https://github.com/xarray-contrib/cupy-xarray/pull/4))
+* Update versioneer ([#12](https://github.com/xarray-contrib/cupy-xarray/pull/12))
+* Add PyPI release workflow ([#13](https://github.com/xarray-contrib/cupy-xarray/pull/13))
+* Fix CI job dependency ([#14](https://github.com/xarray-contrib/cupy-xarray/pull/14))
+
+### Contributors
+
+* [Jacob Tomlinson](https://github.com/jacobtomlinson)
+* [Ray Bell](https://github.com/raybellwaves)
+* [Deepak Cherian](https://github.com/dcherian)
+* [Anderson Banihirwe](https://github.com/andersy005)
+
+**Full Changelog**: <https://github.com/xarray-contrib/cupy-xarray/compare/0.1.0...0.1.1>
+
+---
+
+## Version 0.1.0 - 2020-07-23
+
+_Pre-release_
+
+### Contributors
+
+* [Jacob Tomlinson](https://github.com/jacobtomlinson)
+
+**Full Changelog**: <https://github.com/xarray-contrib/cupy-xarray/compare/0.0.1...0.1.0>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.1.4 - 2023-07-27
+## Version 0.1.4 - 2024-07-27
 
 This release brings several documentation improvements at
 <https://cupy-xarray.readthedocs.io> with a new User Guide, Tutorials and Presentations,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,9 +11,9 @@ import sphinx_autosummary_accessors
 import cupy_xarray  # noqa: F401
 
 project = "cupy-xarray"
-copyright = "2023, cupy-xarray developers"
+copyright = "2020-2024, cupy-xarray developers"
 author = "cupy-xarray developers"
-release = "v0.1"
+release = "v0.1.4"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,11 +76,12 @@ Large parts of this documentations comes from [SciPy 2023 Xarray on GPUs tutoria
    source/contributing
 
 
-**API Reference**:
+**Reference**:
 
 .. toctree::
    :maxdepth: 1
-   :caption: API Reference
+   :caption: Reference
 
    api
+   changelog
 ```


### PR DESCRIPTION
This PR adds a changelog entry for v0.1.4 (and previous v0.1.0 to v0.1.3 releases).

**Preview** at https://cupy-xarray--59.org.readthedocs.build/59/changelog.html