### PR TITLE
Check if Dask is installed

### DIFF
--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -9,9 +9,9 @@ from xarray import (
 try:
     import dask.array
 
-    dask_array_type = dask.array.Array
+    dask_array_type = (dask.array.Array,)
 except ImportError:
-    dask_array_type = None
+    dask_array_type = ()
 
 
 @register_dataarray_accessor("cupy")
@@ -34,7 +34,7 @@ class CupyDataArrayAccessor:
         is_cupy: bool
             Whether the underlying data is a cupy array.
         """
-        if dask_array_type is not None and isinstance(self.da.data, dask_array_type):
+        if isinstance(self.da.data, dask_array_type):
             return isinstance(self.da.data._meta, cp.ndarray)
         return isinstance(self.da.data, cp.ndarray)
 
@@ -61,7 +61,7 @@ class CupyDataArrayAccessor:
         <class 'cupy.ndarray'>
 
         """
-        if dask_array_type is not None and isinstance(self.da.data, dask_array_type):
+        if isinstance(self.da.data, dask_array_type):
             return DataArray(
                 data=self.da.data.map_blocks(cp.asarray),
                 coords=self.da.coords,
@@ -87,7 +87,7 @@ class CupyDataArrayAccessor:
             DataArray with underlying data cast to numpy.
         """
         if self.is_cupy:
-            if dask_array_type is not None and isinstance(self.da.data, dask_array_type):
+            if isinstance(self.da.data, dask_array_type):
                 return DataArray(
                     data=self.da.data.map_blocks(
                         lambda block: block.get(), dtype=self.da.data._meta.dtype

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -34,7 +34,7 @@ class CupyDataArrayAccessor:
         is_cupy: bool
             Whether the underlying data is a cupy array.
         """
-        if dask_array_type and isinstance(self.da.data, dask_array_type):
+        if dask_array_type is not None and isinstance(self.da.data, dask_array_type):
             return isinstance(self.da.data._meta, cp.ndarray)
         return isinstance(self.da.data, cp.ndarray)
 
@@ -61,7 +61,7 @@ class CupyDataArrayAccessor:
         <class 'cupy.ndarray'>
 
         """
-        if dask_array_type and isinstance(self.da.data, dask_array_type):
+        if dask_array_type is not None and isinstance(self.da.data, dask_array_type):
             return DataArray(
                 data=self.da.data.map_blocks(cp.asarray),
                 coords=self.da.coords,
@@ -87,7 +87,7 @@ class CupyDataArrayAccessor:
             DataArray with underlying data cast to numpy.
         """
         if self.is_cupy:
-            if dask_array_type and isinstance(self.da.data, dask_array_type):
+            if dask_array_type is not None and isinstance(self.da.data, dask_array_type):
                 return DataArray(
                     data=self.da.data.map_blocks(
                         lambda block: block.get(), dtype=self.da.data._meta.dtype

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING, Any
+
 import cupy as cp
 from xarray import (
     DataArray,

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -10,8 +10,8 @@ from xarray import (
 
 if TYPE_CHECKING:
     DuckArrayTypes = tuple[type[Any], ...]
+    dask_array_type: DuckArrayTypes
 
-dask_array_type: DuckArrayTypes
 try:
     import dask.array
 

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -34,7 +34,7 @@ class CupyDataArrayAccessor:
         is_cupy: bool
             Whether the underlying data is a cupy array.
         """
-        if isinstance(self.da.data, dask_array_type):
+        if dask_array_type and isinstance(self.da.data, dask_array_type):
             return isinstance(self.da.data._meta, cp.ndarray)
         return isinstance(self.da.data, cp.ndarray)
 
@@ -61,7 +61,7 @@ class CupyDataArrayAccessor:
         <class 'cupy.ndarray'>
 
         """
-        if isinstance(self.da.data, dask_array_type):
+        if dask_array_type and isinstance(self.da.data, dask_array_type):
             return DataArray(
                 data=self.da.data.map_blocks(cp.asarray),
                 coords=self.da.coords,
@@ -87,7 +87,7 @@ class CupyDataArrayAccessor:
             DataArray with underlying data cast to numpy.
         """
         if self.is_cupy:
-            if isinstance(self.da.data, dask_array_type):
+            if dask_array_type and isinstance(self.da.data, dask_array_type):
                 return DataArray(
                     data=self.da.data.map_blocks(
                         lambda block: block.get(), dtype=self.da.data._meta.dtype

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -6,6 +6,10 @@ from xarray import (
     register_dataset_accessor,
 )
 
+if TYPE_CHECKING:
+    DuckArrayTypes = tuple[type[Any], ...]
+
+dask_array_type: DuckArrayTypes
 try:
     import dask.array
 


### PR DESCRIPTION
Closes #61 

If Dask is not installed then `dask_array_type` will be set to `None`. This PR checks this variable before using it.