### PR TITLE
Pin minimum version of furo to 2024.8.6

### DIFF
--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -12,7 +12,7 @@ dependencies:
   - ipython
   - ipykernel
   - ipywidgets
-  - furo
+  - furo>=2024.8.6
   - myst-nb
   - xarray
   - pip:


### PR DESCRIPTION
Try to fix incompatibility with sphinx=8.0 causing `AttributeError: _CascadingStyleSheet is immutable` with old versions of furo.

Full traceback error from Readthedocs:
```python-traceback
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/cupy-xarray/conda/63/lib/python3.10/site-packages/sphinx/events.py", line 100, in emit
    results.append(listener.handler(self.app, *args))
  File "/home/docs/checkouts/readthedocs.org/user_builds/cupy-xarray/conda/63/lib/python3.10/site-packages/furo/__init__.py", line 158, in _html_page_context
    _add_asset_hashes(
  File "/home/docs/checkouts/readthedocs.org/user_builds/cupy-xarray/conda/63/lib/python3.10/site-packages/furo/__init__.py", line 138, in _add_asset_hashes
    static[index].filename = _asset_hash(asset)  # type: ignore
  File "/home/docs/checkouts/readthedocs.org/user_builds/cupy-xarray/conda/63/lib/python3.10/site-packages/sphinx/builders/html/_assets.py", line 54, in __setattr__
    raise AttributeError(msg)
AttributeError: _CascadingStyleSheet is immutable
```


References:
- https://github.com/pradyunsg/furo/discussions/693
- https://github.com/MetOffice/CSET/pull/783#pullrequestreview-2232387207