### PR TITLE
Let user decide which cupy version to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Interface for using cupy in xarray, providing convenience accessors.
 
 ## Installation
 
-> `cupy-xarray` will use an existing cupy installation, hence cupy needs to be installed manually! Please follow cupy's install instructions at <https://docs.cupy.dev/en/stable/install.html> or use the extras install
+> `cupy-xarray` will use an existing cupy installation, hence cupy needs to be installed manually! Please follow cupy's install instructions at <https://docs.cupy.dev/en/stable/install.html>.
 
 From anaconda:
 
@@ -34,14 +34,6 @@ The latest version from Github:
 
 ```console
 pip install git+https://github.com/xarray-contrib/cupy-xarray.git
-```
-
-Install cupy with extras:
-
-```console
-pip install cupy-xarray["source"] # will install the cupy package, which will build cupy from source
-pip install cupy-xarray["cuda11"] # will install the prebuilt cupy-cuda11x package
-pip install cupy-xarray["cuda12"] # will install the prebuilt cupy-cuda12x package
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Install cupy with extras:
 
 ```console
 pip install cupy-xarray["source"] # will install the cupy package, which will build cupy from source
-pip install cupy-xarray["cuda11"] # will install the prebuild cupy-cuda11x package
-pip install cupy-xarray["cuda12"] # will install the prebuild cupy-cuda12x package
+pip install cupy-xarray["cuda11"] # will install the prebuilt cupy-cuda11x package
+pip install cupy-xarray["cuda12"] # will install the prebuilt cupy-cuda12x package
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Interface for using cupy in xarray, providing convenience accessors.
 
 ## Installation
 
+> `cupy-xarray` will use an existing cupy installation, hence cupy needs to be installed manually! Please follow cupy's install instructions at <https://docs.cupy.dev/en/stable/install.html> or use the extras install
+
 From anaconda:
 
 ```console
@@ -32,6 +34,14 @@ The latest version from Github:
 
 ```console
 pip install git+https://github.com/xarray-contrib/cupy-xarray.git
+```
+
+Install cupy with extras:
+
+```console
+pip install cupy-xarray["source"] # will install the cupy package, which will build cupy from source
+pip install cupy-xarray["cuda11"] # will install the prebuild cupy-cuda11x package
+pip install cupy-xarray["cuda12"] # will install the prebuild cupy-cuda12x package
 ```
 
 ## Usage

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -1,6 +1,11 @@
 from typing import TYPE_CHECKING, Any
+import warnings
 
-import cupy as cp
+try:
+    import cupy as cp
+except ImportError as e:
+    warnings.warn("Cupy is not installed. cupy-xarray expects cupy to be manually installed. Please install cupy either by following the instructions at https://docs.cupy.dev/en/stable/install.html or by isntalling cupy-xaray with extras, e.g. `pip install cupy-xarray['source']`. More information can be found in the Readme or at the cupy-xarray documentation.", ImportWarning)
+    raise e
 from xarray import (
     DataArray,
     Dataset,

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -7,7 +7,7 @@ except ImportError as e:
     warnings.warn(
         "Cupy is not installed. cupy-xarray expects cupy to be manually installed. Please install "
         "cupy either by following the instructions at https://docs.cupy.dev/en/stable/install.html "
-        "or by isntalling cupy-xaray with extras, e.g. `pip install cupy-xarray['source']`. More "
+        "or by installing cupy-xaray with extras, e.g. `pip install cupy-xarray['source']`. More "
         "information can be found in the Readme or at the cupy-xarray documentation.",
         ImportWarning,
         stacklevel=2,

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -1,10 +1,13 @@
-from typing import TYPE_CHECKING, Any
 import warnings
+from typing import TYPE_CHECKING, Any
 
 try:
     import cupy as cp
 except ImportError as e:
-    warnings.warn("Cupy is not installed. cupy-xarray expects cupy to be manually installed. Please install cupy either by following the instructions at https://docs.cupy.dev/en/stable/install.html or by isntalling cupy-xaray with extras, e.g. `pip install cupy-xarray['source']`. More information can be found in the Readme or at the cupy-xarray documentation.", ImportWarning)
+    warnings.warn(
+        "Cupy is not installed. cupy-xarray expects cupy to be manually installed. Please install cupy either by following the instructions at https://docs.cupy.dev/en/stable/install.html or by isntalling cupy-xaray with extras, e.g. `pip install cupy-xarray['source']`. More information can be found in the Readme or at the cupy-xarray documentation.",
+        ImportWarning,
+    )
     raise e
 from xarray import (
     DataArray,

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -5,8 +5,12 @@ try:
     import cupy as cp
 except ImportError as e:
     warnings.warn(
-        "Cupy is not installed. cupy-xarray expects cupy to be manually installed. Please install cupy either by following the instructions at https://docs.cupy.dev/en/stable/install.html or by isntalling cupy-xaray with extras, e.g. `pip install cupy-xarray['source']`. More information can be found in the Readme or at the cupy-xarray documentation.",
+        "Cupy is not installed. cupy-xarray expects cupy to be manually installed. Please install "
+        "cupy either by following the instructions at https://docs.cupy.dev/en/stable/install.html "
+        "or by isntalling cupy-xaray with extras, e.g. `pip install cupy-xarray['source']`. More "
+        "information can be found in the Readme or at the cupy-xarray documentation.",
         ImportWarning,
+        stacklevel=2,
     )
     raise e
 from xarray import (

--- a/cupy_xarray/accessors.py
+++ b/cupy_xarray/accessors.py
@@ -6,9 +6,7 @@ try:
 except ImportError as e:
     warnings.warn(
         "Cupy is not installed. cupy-xarray expects cupy to be manually installed. Please install "
-        "cupy either by following the instructions at https://docs.cupy.dev/en/stable/install.html "
-        "or by installing cupy-xaray with extras, e.g. `pip install cupy-xarray['source']`. More "
-        "information can be found in the Readme or at the cupy-xarray documentation.",
+        "cupy by following the instructions at https://docs.cupy.dev/en/stable/install.html.",
         ImportWarning,
         stacklevel=2,
     )

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,8 +43,8 @@ Install cupy with extras:
 
 ```console
 pip install cupy-xarray["source"] # will install the cupy package, which will build cupy from source
-pip install cupy-xarray["cuda11"] # will install the prebuild cupy-cuda11x package
-pip install cupy-xarray["cuda12"] # will install the prebuild cupy-cuda12x package
+pip install cupy-xarray["cuda11"] # will install the prebuilt cupy-cuda11x package
+pip install cupy-xarray["cuda12"] # will install the prebuilt cupy-cuda12x package
 ```
 
 ## Acknowledgements

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ CuPy-Xarray is a Python library that leverages [CuPy](https://cupy.dev/), a GPU 
 
 ## Installation
 
-> `cupy-xarray` will use an existing cupy installation, hence cupy needs to be installed manually! Please follow cupy's install instructions at <https://docs.cupy.dev/en/stable/install.html> or use the extras install
+> `cupy-xarray` will use an existing cupy installation, hence cupy needs to be installed manually! Please follow cupy's install instructions at <https://docs.cupy.dev/en/stable/install.html>.
 
 CuPy-Xarray can be installed using `pip` or `conda`:
 
@@ -37,14 +37,6 @@ The latest version from Github:
 
 ```bash
 pip install git+https://github.com/xarray-contrib/cupy-xarray.git
-```
-
-Install cupy with extras:
-
-```console
-pip install cupy-xarray["source"] # will install the cupy package, which will build cupy from source
-pip install cupy-xarray["cuda11"] # will install the prebuilt cupy-cuda11x package
-pip install cupy-xarray["cuda12"] # will install the prebuilt cupy-cuda12x package
 ```
 
 ## Acknowledgements

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,8 @@ CuPy-Xarray is a Python library that leverages [CuPy](https://cupy.dev/), a GPU 
 
 ## Installation
 
+> `cupy-xarray` will use an existing cupy installation, hence cupy needs to be installed manually! Please follow cupy's install instructions at <https://docs.cupy.dev/en/stable/install.html> or use the extras install
+
 CuPy-Xarray can be installed using `pip` or `conda`:
 
 From Conda Forge:
@@ -35,6 +37,14 @@ The latest version from Github:
 
 ```bash
 pip install git+https://github.com/xarray-contrib/cupy-xarray.git
+```
+
+Install cupy with extras:
+
+```console
+pip install cupy-xarray["source"] # will install the cupy package, which will build cupy from source
+pip install cupy-xarray["cuda11"] # will install the prebuild cupy-cuda11x package
+pip install cupy-xarray["cuda12"] # will install the prebuild cupy-cuda12x package
 ```
 
 ## Acknowledgements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "cupy",
     "xarray>=2024.02.0",
 ]
 
@@ -24,6 +23,16 @@ test = [
     "dask",
     "pytest",
 ]
+source = [
+    "cupy"
+]
+cuda12 = [
+    "cupy-cuda12x",
+]
+cuda11 = [
+    "cupy-cuda11x",
+]
+
 
 [tool.ruff]
 line-length = 100  # E501 (line-too-long)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,16 +23,6 @@ test = [
     "dask",
     "pytest",
 ]
-source = [
-    "cupy"
-]
-cuda12 = [
-    "cupy-cuda12x",
-]
-cuda11 = [
-    "cupy-cuda11x",
-]
-
 
 [tool.ruff]
 line-length = 100  # E501 (line-too-long)


### PR DESCRIPTION
Implement solution for #66 as discussed.

Remove cupy from dependencies and add three extras where each requires a different cupy version: cupy (building from source), and the two prebuild cupy-cuda12x and cupy-cuda11x

Closes #66 
