### PR TITLE
Fix deprecated readthedocs config and bump actions/upload-artifacts to 4

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -51,7 +51,7 @@ jobs:
           else
             echo "✅ Looks good"
           fi
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: releases
           path: dist
@@ -61,7 +61,7 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
           name: releases
           path: dist

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,10 @@ build:
   tools:
     python: "mambaforge-23.11"
 
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
 # Optionally set the version of Python and requirements required to build your docs
 conda:
   environment: ci/doc.yml


### PR DESCRIPTION
References:
- https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/