### PR TITLE
Set license and license-files key in project metadata to follow PEP639

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -22,13 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'xarray-contrib/cupy-xarray'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
-        name: Install Python
+          persist-credentials: false
+
+      - name: Install Python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: '3.8'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: "3.8"
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [build-system]
-requires = ["setuptools", "versioneer[toml]"]
+requires = ["setuptools>=77", "versioneer[toml]"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "cupy-xarray"
 description = "Interface for using cupy in xarray, providing convenience accessors."
 authors = [{name = "cupy-xarray developers"}]
-license = {text = "Apache License"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [


### PR DESCRIPTION
Adhere to https://peps.python.org/pep-0639 to specify Apache-2.0 license in SPDX format. Works on setuptools>=77.

References:
- https://peps.python.org/pep-0639
- https://discuss.python.org/t/pep-639-round-3-improving-license-clarity-with-better-package-metadata/53020/128 (PyPI added support for PEP639 in mid-Nov 2024)
- https://hugovk.dev/blog/2025/improving-licence-metadata/