### PR TITLE
Set minimum supported version to Python 3.10+

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -22,11 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'xarray-contrib/cupy-xarray'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
-        name: Install Python
+          persist-credentials: false
+
+      - name: Install Python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - "--py38-plus"
+          - "--py310-plus"
 
   - repo: https://github.com/keewis/blackdoc
     rev: v0.3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Interface for using cupy in xarray, providing convenience accesso
 authors = [{name = "cupy-xarray developers"}]
 license = {text = "Apache License"}
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Following [SPEC 0](https://scientific-python.org/specs/spec-0000/) policy where Python 3.9 should be dropped in 2023 quarter 4.

Technically we can go directly to Python 3.11+, but let's do 2 version jumps (3.8 to 3.10+) instead of 3 version jumps (3.8 to 3.11+ :slightly_smiling_face:

