### PR TITLE
Pin to sphinx<9

### DIFF
--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -5,7 +5,7 @@ dependencies:
   - cupy-core
   - pip
   - python=3.10
-  - sphinx
+  - sphinx<9 # https://github.com/xarray-contrib/sphinx-autosummary-accessors/issues/165
   - sphinx-design
   - sphinx-copybutton
   - sphinx-autosummary-accessors


### PR DESCRIPTION
Workaround for `AttributeError: type object 'Autosummary' has no attribute 'create_documenter'`.

Xref https://github.com/xarray-contrib/sphinx-autosummary-accessors/issues/165