### PR TITLE
Configure trusted publishing to PyPI

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -73,7 +73,7 @@ jobs:
           path: dist
 
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -62,10 +62,17 @@ jobs:
           name: releases
           path: dist
 
-  upload-to-pypi:
+  pypi-publish:
+    name: Publish Python 🐍 distribution 📦 to PyPI
     needs: build-artifacts
-    if: github.event_name == 'release'
+    if: github.repository == 'xarray-contrib/cupy-xarray' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/cupy-xarray/
+    permissions:
+      id-token: write # IMPORTANT: mandatory for trusted OIDC publishing
+
     steps:
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
@@ -75,6 +82,5 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+          print-hash: true
           verbose: true


### PR DESCRIPTION
Secure publishing of sdist and wheel to PyPI.

TODO:
- [x] Configure `pypa/gh-action-pypi-publish` workflow to use OIDC publishing
- [ ] Ensure trusted publishing is set up at https://pypi.org/manage/project/cupy-xarray/settings/publishing/
- [ ] Revoke token secret from GitHub and PyPI settings

References:
- https://docs.pypi.org/trusted-publishers/adding-a-publisher/
- https://docs.pypi.org/trusted-publishers/using-a-publisher/

Closes #87