### PR TITLE
SPEC 0: Bump minimum supported version to Python 3.12, xarray 2024.7.0

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - "--py310-plus"
+          - "--py312-plus"
 
   - repo: https://github.com/keewis/blackdoc
     rev: v0.4.6

--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - cupy-core!=14.0.0,!=14.0.1 # https://github.com/cupy/cupy/issues/9777
   - pip
-  - python=3.10
+  - python=3.12
   - sphinx
   - sphinx-design
   - sphinx-copybutton

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,15 +9,15 @@ authors = [{name = "cupy-xarray developers"}]
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
 ]
-dynamic = ["version"]
 dependencies = [
-    "xarray>=2024.02.0",
+    "xarray>=2024.7.0",
 ]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 


### PR DESCRIPTION
Following [SPEC 0](https://scientific-python.org/specs/spec-0000/) policy where Python 3.11 should be dropped in 2025 quarter 4, and xarray 2024.6.0 should be dropped in 2026 quarter 2.

Doing two Python version jumps (from Python 3.10 to 3.12) because we didn't go to Python 3.11+ directly last time (https://github.com/xarray-contrib/cupy-xarray/pull/76), and time flies :wing: